### PR TITLE
Mqtt client MVP

### DIFF
--- a/mqtt-client/mqtt_client/Client.py
+++ b/mqtt-client/mqtt_client/Client.py
@@ -112,7 +112,7 @@ class Client(Plugin):
 	def onMessage(self, client, userdata, msg):
 		try:
 			data = json.loads(str(msg.payload.decode('utf-8')))
-			deviceId = msg.topic.split('/')[2] # _topic_/device/_id_/cmd
+			deviceId = msg.topic.split('/')[-2] # _topic_/device/_id_/cmd
 			device = self.deviceManager.device(int(deviceId))
 			if device:
 				device.command(data.get('action'), data.get('value'))

--- a/mqtt-client/setup.py
+++ b/mqtt-client/setup.py
@@ -12,8 +12,8 @@ setup(
 	description='Plugin to connect to a MQTT broker',
 	icon='mqtt.png',
 	color='#660066',
-	author='Artem Vitiuk',
-	author_email='artem@vitiuk.me',
+	author='Telldus Technologies',
+	author_email='info.tech@telldus.se',
 	category='notifications',
 	packages=['mqtt_client'],
 	entry_points={

--- a/mqtt-client/setup.py
+++ b/mqtt-client/setup.py
@@ -8,15 +8,15 @@ except ImportError:
 
 setup(
 	name='MQTT Client',
-	version='1.0',
+	version='1.1',
 	description='Plugin to connect to a MQTT broker',
 	icon='mqtt.png',
 	color='#660066',
-	author='Telldus Technologies',
-	author_email='info.tech@telldus.se',
+	author='Artem Vitiuk',
+	author_email='artem@vitiuk.me',
 	category='notifications',
 	packages=['mqtt_client'],
-	entry_points={ \
+	entry_points={
 		'telldus.startup': ['c = mqtt_client:Client [cREQ]']
 	},
 	extras_require=dict(cREQ='Base>=0.1\nTelldus>=0.1'),


### PR DESCRIPTION
Adds possibility to call device methods using MQTT.

Format:
* **topic:** `_topic_/device/_device_id_/cmd`  (eg. `telldus/device/11/cmd`)
* **payload:** `{"action": "actionName", "value": "optional"}` (eg. `{"action": "bell"}`)

In addition, implements [LWT](https://www.hivemq.com/blog/mqtt-essentials-part-9-last-will-and-testament/) as a retained message (`Online|Offline`) to `_topic_/status`.